### PR TITLE
Fix occasional crash in Adafruit_TLC59711::write()

### DIFF
--- a/Adafruit_TLC59711.cpp
+++ b/Adafruit_TLC59711.cpp
@@ -136,9 +136,10 @@ void Adafruit_TLC59711::write() {
 
   if (_clk >= 0)
     delayMicroseconds(200);
-  else
+  else {
     delayMicroseconds(2);
-  _spi->endTransaction();
+    _spi->endTransaction();
+  }
 
   interrupts();
 }


### PR DESCRIPTION
The previous version would call _spi->endTransaction() unconditionally at the end of execution. If the Adafruit_TLC59711 instance is created for software SPI, the _spi object will not have been initialized. The function previously worked on my board, but recently started causing crashes. By checking that _clk < 0 before calling endTransaction, the crashes should go away.